### PR TITLE
Minor Fix in the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.tfvars
 **.log
 *.plan
+*.vscode

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Using the code in the repo will require having the following tools installed:
 Additionally, Terraform repos often have a local variables file (`terraform.tfvars`) that is **not** committed to the repo because it will often have creds or API keys in it. For this repo, it's quite simple:
 
 ```hcl
-cat << EOF > terraform.tfvars
-rosa_cluster_name = "rosa-test"
-rosa_compute_node_count = "3"  # Set to 3 for HA, 2 for single-AZ
-rosa_offline_access_token = "**************" # Get from console.redhat.com
+cat << EOF > terraform.auto.tfvars
+cluster_name = "rosa-test"
+compute_nodes = "3"  # Set to 3 for HA, 2 for single-AZ
+offline_access_token = "**************" # Get from https://console.redhat.com/openshift/token/rosa/show
 rosa_version = "4.10.15" # Needs to be a supported version by ROSA
+aws_region           = "us-west-1" # Optional, only if you're not selecting us-west-2 region
+availability_zones   = ["us-west-1a", "eu-west-1b", "eu-west-1c"] # Optional, only if you're not selecting us-west-2 region
 EOF
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -1,25 +1,25 @@
 terraform {
-    required_providers {
-        ocm = {
-            version = ">= 0.1.9"
-            source = "rh-mobb/ocm"
-        }
+  required_providers {
+    ocm = {
+      version = ">= 0.1.9"
+      source  = "rh-mobb/ocm"
     }
+  }
 }
 
 provider "ocm" {
-    token = "${var.offline_access_token}"
+  token = var.offline_access_token
 }
 
 provider "aws" {
-    # region = "${var.region}"
-    # access_key = "${var.access_key}"
-    # secret_key = "${var.secret_key}"
-    profile = "default"
+  region = var.aws_region
+  # access_key = "${var.access_key}"
+  # secret_key = "${var.secret_key}"
+  profile = "default"
 
-    ignore_tags {
-        key_prefixes = ["kubernetes.io/"]
-    }
+  ignore_tags {
+    key_prefixes = ["kubernetes.io/"]
+  }
 }
 
 data "aws_caller_identity" "current" {}

--- a/rosa.tf
+++ b/rosa.tf
@@ -1,43 +1,43 @@
 locals {
   sts_roles = {
-      role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-Installer-Role",
-      support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-Support-Role",
-      operator_iam_roles = [
-        {
-          name =  "cloud-credential-operator-iam-ro-creds",
-          namespace = "openshift-cloud-credential-operator",
-          role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-cloud-credential-operator-cloud-c",
-        },
-        {
-          name =  "installer-cloud-credentials",
-          namespace = "openshift-image-registry",
-          role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-image-registry-installer-cloud-cr",
-        },
-        {
-          name =  "cloud-credentials",
-          namespace = "openshift-ingress-operator",
-          role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-ingress-operator-cloud-credential",
-        },
-        {
-          name =  "ebs-cloud-credentials",
-          namespace = "openshift-cluster-csi-drivers",
-          role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-cluster-csi-drivers-ebs-cloud-cre",
-        },
-        {
-          name =  "cloud-credentials",
-          namespace = "openshift-cloud-network-config-controller",
-          role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-cloud-network-config-controller-c",
-        },
-        {
-          name =  "aws-cloud-credentials",
-          namespace = "openshift-machine-api",
-          role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-machine-api-aws-cloud-credentials",
-        },
-      ]
-      instance_iam_roles = {
-        master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-ControlPlane-Role",
-        worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-Worker-Role"
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-Installer-Role",
+    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-Support-Role",
+    operator_iam_roles = [
+      {
+        name      = "cloud-credential-operator-iam-ro-creds",
+        namespace = "openshift-cloud-credential-operator",
+        role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-cloud-credential-operator-cloud-c",
       },
+      {
+        name      = "installer-cloud-credentials",
+        namespace = "openshift-image-registry",
+        role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-image-registry-installer-cloud-cr",
+      },
+      {
+        name      = "cloud-credentials",
+        namespace = "openshift-ingress-operator",
+        role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-ingress-operator-cloud-credential",
+      },
+      {
+        name      = "ebs-cloud-credentials",
+        namespace = "openshift-cluster-csi-drivers",
+        role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-cluster-csi-drivers-ebs-cloud-cre",
+      },
+      {
+        name      = "cloud-credentials",
+        namespace = "openshift-cloud-network-config-controller",
+        role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-cloud-network-config-controller-c",
+      },
+      {
+        name      = "aws-cloud-credentials",
+        namespace = "openshift-machine-api",
+        role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}-openshift-machine-api-aws-cloud-credentials",
+      },
+    ]
+    instance_iam_roles = {
+      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-ControlPlane-Role",
+      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ManagedOpenShift-Worker-Role"
+    },
   }
   aws_access_key_id     = length(aws_iam_access_key.admin_key) > 0 ? aws_iam_access_key.admin_key[0].id : null
   aws_secret_access_key = length(aws_iam_access_key.admin_key) > 0 ? aws_iam_access_key.admin_key[0].secret : null
@@ -45,31 +45,32 @@ locals {
 
 resource "aws_iam_access_key" "admin_key" {
   count = var.enable_sts ? 0 : 1
-  user = data.aws_iam_user.admin[0].user_name
+  user  = data.aws_iam_user.admin[0].user_name
 }
 
 resource "ocm_cluster" "rosa_cluster" {
-  product            = "rosa"
-  cloud_provider     = "aws"
-  name               = var.cluster_name
-  cloud_region       = var.aws_region
-  compute_nodes      = var.compute_nodes
-  aws_account_id     = data.aws_caller_identity.current.account_id
-  aws_subnet_ids     = var.enable_private_link ? module.rosa-vpc.private_subnets : concat(module.rosa-vpc.private_subnets, module.rosa-vpc.public_subnets)
+  product        = "rosa"
+  cloud_provider = "aws"
+  name           = var.cluster_name
+  #version        = var.rosa_version
+  cloud_region   = var.aws_region
+  compute_nodes  = var.compute_nodes
+  aws_account_id = data.aws_caller_identity.current.account_id
+  aws_subnet_ids = var.enable_private_link ? module.rosa-vpc.private_subnets : concat(module.rosa-vpc.private_subnets, module.rosa-vpc.public_subnets)
   # aws_subnet_ids     = concat(module.rosa-vpc.private_subnets, module.rosa-vpc.public_subnets)
-  machine_cidr       = module.rosa-vpc.vpc_cidr_block
-  aws_private_link   = var.enable_private_link
+  machine_cidr     = module.rosa-vpc.vpc_cidr_block
+  aws_private_link = var.enable_private_link
   # aws_private_link   = false
   multi_az           = length(module.rosa-vpc.private_subnets) == 3 ? true : false
   availability_zones = var.availability_zones
-  properties         = {
+  properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }
   wait = var.enable_sts ? false : true
-  sts = var.enable_sts ? local.sts_roles : null
-    depends_on = [
-        module.rosa-vpc
-    ]
+  sts  = var.enable_sts ? local.sts_roles : null
+  depends_on = [
+    module.rosa-vpc
+  ]
   # aws_access_key_id     = local.aws_access_key_id
   # aws_secret_access_key = local.aws_secret_access_key
   aws_access_key_id     = var.enable_sts ? (length(aws_iam_access_key.admin_key) > 0 ? aws_iam_access_key.admin_key[0].id : null) : null
@@ -79,12 +80,12 @@ resource "ocm_cluster" "rosa_cluster" {
   }
 }
 
-module sts_roles {
-    count = var.enable_sts ? 1 : 0
-    source  = "rh-mobb/rosa-sts-roles/aws"
-    create_account_roles = false
-    clusters = [{
-        id = ocm_cluster.rosa_cluster.id
-        operator_role_prefix = var.cluster_name
-    }]
+module "sts_roles" {
+  count                = var.enable_sts ? 1 : 0
+  source               = "rh-mobb/rosa-sts-roles/aws"
+  create_account_roles = false
+  clusters = [{
+    id                   = ocm_cluster.rosa_cluster.id
+    operator_role_prefix = var.cluster_name
+  }]
 }

--- a/vars.tf
+++ b/vars.tf
@@ -1,12 +1,12 @@
 variable "aws_region" {
-    type = string
-    default = "us-east-2"
+  type    = string
+  default = "us-east-2"
 }
 
 variable "cluster_name" {
-    type = string
-    description = "The name of the ROSA cluster to create"
-    default = "rosa-cluster"
+  type        = string
+  description = "The name of the ROSA cluster to create"
+  default     = "rosa-cluster"
 }
 
 # variable "network_type" {
@@ -29,68 +29,68 @@ variable "cluster_name" {
 # }
 
 # variable "rosa_version" {
-#     type = string
-#     description = "The version of ROSA to be deployed"
-#     default = "4.10.20"
+#   type        = string
+#   description = "The version of ROSA to be deployed"
+#   default     = "4.10.20"
 # }
 
 variable "compute_nodes" {
-    type = string
-    description = "The number of computer nodes to create. Must be a minimum of 2 for a single-AZ cluster, 3 for multi-AZ."
-    default = "3"
+  type        = string
+  description = "The number of computer nodes to create. Must be a minimum of 2 for a single-AZ cluster, 3 for multi-AZ."
+  default     = "3"
 }
 
 variable "compute_node_instance_type" {
-    type = string
-    description = "The EC2 instance type to use for compute nodes"
-    default = "m5.xlarge"
+  type        = string
+  description = "The EC2 instance type to use for compute nodes"
+  default     = "m5.xlarge"
 }
 
 variable "host_prefix" {
-    type = string
-    description = "The subnet mask to assign to each compute node in the cluster"
-    default = "23"
+  type        = string
+  description = "The subnet mask to assign to each compute node in the cluster"
+  default     = "23"
 }
 
 variable "offline_access_token" {
-    type = string
-    description = "The OCM API access token for your account"
+  type        = string
+  description = "The OCM API access token for your account"
 }
 
 variable "availability_zones" {
-  type = list
+  type        = list(any)
   description = "The availability zones to use for the cluster"
-  default = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
 }
 
 variable "machine_cidr_block" {
-  type = string
+  type        = string
   description = "value of the CIDR block to use for the VPC"
-  default = "10.66.0.0/16"
+  default     = "10.66.0.0/16"
 }
 
 variable "private_subnet_cidrs" {
-  type = list
+  type        = list(any)
   description = "The CIDR blocks to use for the private subnets"
-  default = ["10.66.1.0/24", "10.66.2.0/24", "10.66.3.0/24"]
+  default     = ["10.66.1.0/24", "10.66.2.0/24", "10.66.3.0/24"]
 }
 
 variable "public_subnet_cidrs" {
-  type = list
+  type        = list(any)
   description = "The CIDR blocks to use for the public subnets"
-  default = ["10.66.101.0/24", "10.66.102.0/24", "10.66.103.0/24"]
+  default     = ["10.66.101.0/24", "10.66.102.0/24", "10.66.103.0/24"]
 }
 
 variable "enable_private_link" {
-  type = bool
+  type        = bool
   description = "This enables private link"
-  default = false
+  default     = false
 }
 
 variable "enable_sts" {
-  type = bool
+  type        = bool
   description = "This enables STS"
-  default = true
+  default     = true
 }
 
 # variable "aws_access_key_id" {


### PR DESCRIPTION
This PR fixes some minor things in the README docs and in the TF code:

- Uses the correct name of the variables for cluster_name, compute_nodes, and compute_token as are defined in the vars.tf
- Uses terraform.auto.tfvars for avoid the need to include -var-file with the tfvars specifically (in some corner cases tf not imports properly terraform.tfvars)
- Linted and formatted the tf code
- Include aws_regions to not hardcode us-west-2 (the aws vpc module doesn't work well for other aws_regions if only the az is defined, needs to be explicit aws_region defined)
- Tested and works perfectly in other aws_regions (tested in eu-west-1 / Ireland)