### PR TITLE
rosa_cluster_wait added to wait for rosa provisioning

### DIFF
--- a/rosa.tf
+++ b/rosa.tf
@@ -89,3 +89,7 @@ module "sts_roles" {
     operator_role_prefix = var.cluster_name
   }]
 }
+
+resource "ocm_cluster_wait" "rosa_cluster_wait" {
+  cluster = ocm_cluster.rosa_cluster.id
+}


### PR DESCRIPTION
rosa_cluster_wait added to rosa.tf file so that terraform waits for the cluster to come up before completing and returning the prompt 